### PR TITLE
Change "chunk size" from signed to unsigned 32 bit

### DIFF
--- a/ewave.py
+++ b/ewave.py
@@ -159,9 +159,9 @@ class wavfile(object):
             return
         self.fp.seek(4)
         self.fp.write(
-            struct.pack(b"<l", self._data_offset + self._bytes_written - 8))
+            struct.pack(b"<L", self._data_offset + self._bytes_written - 8))
         self.fp.seek(self._data_offset - 4)
-        self.fp.write(struct.pack(b"<l", self._bytes_written))
+        self.fp.write(struct.pack(b"<L", self._bytes_written))
         self.fp.flush()
         return self
 


### PR DESCRIPTION
ewave is dying on writing files larger than 2G. I'm fairly certain the issue is that the 32 bits in the header that define the chunk size should be _unsigned_. All tests still pass, likely because the positive numbers in two-compliment encoding are equal to their unsigned equivalent.

Sox seems to be able to sensibly read wav files created with an unsigned `chunk size` header. As does praat, aplay and totem.
